### PR TITLE
Add striped rows in contracts table

### DIFF
--- a/script.js
+++ b/script.js
@@ -331,8 +331,11 @@ const zitatContainer = document.getElementById("zitat-des-tages");
         });
       });
 
+      let rowIndex = 0;
       vertraege.forEach((v) => {
         const row = document.createElement("tr");
+        row.classList.add(rowIndex % 2 === 0 ? "row-even" : "row-odd");
+        rowIndex++;
         row.innerHTML = `
           <td>${v.name}</td>
           <td>${v.kosten.toFixed(2)} €</td>

--- a/vertraege.html
+++ b/vertraege.html
@@ -87,11 +87,11 @@
       text-align: left;
     }
 
-    table.vertraege tbody tr:nth-child(odd) {
+    table.vertraege tr.row-even {
       background-color: #f8f8f8;
     }
 
-    table.vertraege tbody tr:nth-child(even) {
+    table.vertraege tr.row-odd {
       background-color: #ffffff;
     }
 


### PR DESCRIPTION
## Summary
- style contract rows with `row-even` / `row-odd`
- assign alternating row classes when rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841641d0da483258de60352dcc35c29