### PR TITLE
Fix IndexedDB store creation

### DIFF
--- a/Einkaufsliste.html
+++ b/Einkaufsliste.html
@@ -134,12 +134,16 @@
 
     const dbName = "KnetenkingDB";
     const storeName = "einkaufsliste";
+    const dbVersion = 2; // neue Version für zusätzliche ObjectStores
     let db;
 
-    const request = indexedDB.open(dbName, 1);
+    const request = indexedDB.open(dbName, dbVersion);
 
     request.onupgradeneeded = function (event) {
       db = event.target.result;
+      if (!db.objectStoreNames.contains("todo_liste")) {
+        db.createObjectStore("todo_liste", { keyPath: "id", autoIncrement: true });
+      }
       if (!db.objectStoreNames.contains(storeName)) {
         db.createObjectStore(storeName, { keyPath: "id", autoIncrement: true });
       }

--- a/to-do.html
+++ b/to-do.html
@@ -134,14 +134,18 @@
 
     const dbName = "KnetenkingDB";
     const storeName = "todo_liste";
+    const dbVersion = 2; // neue Version für zusätzliche ObjectStores
     let db;
 
-    const request = indexedDB.open(dbName, 1);
+    const request = indexedDB.open(dbName, dbVersion);
 
     request.onupgradeneeded = function (event) {
       db = event.target.result;
       if (!db.objectStoreNames.contains(storeName)) {
         db.createObjectStore(storeName, { keyPath: "id", autoIncrement: true });
+      }
+      if (!db.objectStoreNames.contains("einkaufsliste")) {
+        db.createObjectStore("einkaufsliste", { keyPath: "id", autoIncrement: true });
       }
     };
 


### PR DESCRIPTION
## Summary
- update indexedDB version to initialize missing object stores
- ensure both todo and einkaufsliste stores exist regardless of load order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847f117199c8325abf0c9e52357237c