### PR TITLE
Enable PWA support

### DIFF
--- a/Einkaufsliste.html
+++ b/Einkaufsliste.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <title>🛒 Einkaufsliste</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#e6f2ff" />
+  <link rel="manifest" href="manifest.json" />
   <style>
     body {
       margin: 1em;
@@ -219,6 +221,7 @@
       };
     });
   </script>
+  <script src="sw-register.js"></script>
 
-</body>
+  </body>
 </html>

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#4a90e2"/>
+  <text x="64" y="72" font-size="64" text-anchor="middle" fill="white" font-family="sans-serif" dominant-baseline="middle">KK</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -93,5 +93,6 @@
   </div>
 
   <script src="script.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Knetenking",
+  "short_name": "Knetenking",
+  "start_url": "index.html",
+  "display": "standalone",
+  "background_color": "#e6f2ff",
+  "theme_color": "#e6f2ff",
+  "icons": [
+    {
+      "src": "icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/settings.html
+++ b/settings.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <title>⚙️ Einstellungen</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#e6f2ff" />
+  <link rel="manifest" href="manifest.json" />
   <style>
     body {
       margin: 1em;
@@ -57,7 +59,8 @@
   <script>
     // Aktiviere den Mobile-Modus
     document.body.classList.add("mobile-mode");
-  </script>
+    </script>
+    <script src="sw-register.js"></script>
 
-</body>
+  </body>
 </html>

--- a/sw-register.js
+++ b/sw-register.js
@@ -1,0 +1,7 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('sw.js').catch(err => {
+      console.error('Service worker registration failed:', err);
+    });
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'knetenking-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/vertraege.html',
+  '/to-do.html',
+  '/Einkaufsliste.html',
+  '/settings.html',
+  '/script.js',
+  '/sw-register.js',
+  '/manifest.json',
+  '/icon.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names =>
+      Promise.all(names.filter(n => n !== CACHE_NAME).map(n => caches.delete(n)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(res => res || fetch(event.request))
+  );
+});

--- a/to-do.html
+++ b/to-do.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <title>✅️ To Do</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#e6f2ff" />
+  <link rel="manifest" href="manifest.json" />
   <style>
     body {
       margin: 1em;
@@ -221,6 +223,7 @@
       };
     });
   </script>
+  <script src="sw-register.js"></script>
 
-</body>
+  </body>
 </html>

--- a/vertraege.html
+++ b/vertraege.html
@@ -216,5 +216,6 @@
 </div>
 
 <script src="script.js"></script>
+<script src="sw-register.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a web app manifest and a basic icon
- create service worker and register it on each page
- include manifest and service worker registration in all HTML pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847fad48c0083259086269f24b257cd