### PR TITLE
Add PNG icons for PWA

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 128 128">
-  <rect width="128" height="128" fill="#4a90e2"/>
-  <text x="64" y="72" font-size="64" text-anchor="middle" fill="white" font-family="sans-serif" dominant-baseline="middle">KK</text>
-</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,14 @@
   "theme_color": "#e6f2ff",
   "icons": [
     {
-      "src": "icon.svg",
-      "sizes": "any",
-      "type": "image/svg+xml"
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ]
 }

--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,8 @@ const ASSETS = [
   '/script.js',
   '/sw-register.js',
   '/manifest.json',
-  '/icon.svg'
+  '/icon-192.png',
+  '/icon-512.png'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- include 192x192 and 512x512 icons in manifest
- remove unused icon.svg and update service worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68480edb9fc48325a07cfc3dc57cc127