### PR TITLE
Improve layout for start and article pages

### DIFF
--- a/artikel-des-tages.html
+++ b/artikel-des-tages.html
@@ -18,14 +18,14 @@
     h1 {
       font-size: 22px;
       text-align: center;
-      margin: 0 0 1.5em 0;
+      margin: 2em 0 1.5em 0;
     }
 
     .zurueck-button {
       position: absolute;
       top: 1em;
       right: 1em;
-      font-size: 22px;
+      font-size: 24px;
       background: none;
       border: none;
       color: #4a90e2;
@@ -40,7 +40,7 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="zurueck-button">🏠 Zur Startseite</a>
+  <a href="index.html" class="zurueck-button" aria-label="Zur Startseite">🏠</a>
   <h1>📚 Artikel des Tages</h1>
   <div id="artikel-container">Lade Artikel des Tages...</div>
 

--- a/bild-des-tages.html
+++ b/bild-des-tages.html
@@ -19,14 +19,14 @@
     h1 {
       font-size: 22px;
       text-align: center;
-      margin: 0 0 1.5em 0;
+      margin: 2em 0 1.5em 0;
     }
 
     .zurueck-button {
       position: absolute;
       top: 1em;
       right: 1em;
-      font-size: 22px;
+      font-size: 24px;
       background: none;
       border: none;
       color: #4a90e2;
@@ -41,7 +41,7 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="zurueck-button">🏠 Zur Startseite</a>
+  <a href="index.html" class="zurueck-button" aria-label="Zur Startseite">🏠</a>
   <h1>🖼️ Bild des Tages</h1>
   <div id="bild-container">Lade Bild des Tages...</div>
 

--- a/index.html
+++ b/index.html
@@ -66,8 +66,8 @@
       cursor: pointer;
       transition: background-color 0.3s ease;
       text-decoration: none;
-      width: 90%;
-      max-width: 275px;
+      width: 100%;
+      max-width: 400px;
       text-align: center;
       display: block;
       margin: 0 auto;


### PR DESCRIPTION
## Summary
- widen start page tiles so "Bild des Tages" and "Artikel des Tages" labels stay on one line
- replace mobile "Zur Startseite" buttons with top-right home icon on daily image and article pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c161bd92f48325a8142831bcba9b1e