### PR TITLE
Shrink home page buttons and tighten spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       flex-direction: column;
       align-items: center;
       padding-top: 4em;
-      gap: 2em;
+      gap: 1em;
     }
 
     #start-banner #logo {
@@ -53,12 +53,12 @@
       flex-direction: column;
       align-items: center;
       gap: 1em;
-      margin-top: 4em;
+      margin-top: 1em;
     }
 
     .kachel {
-      font-size: 36px;
-      padding: 1em 2em;
+      font-size: 28px;
+      padding: 0.5em 1em;
       border-radius: 24px;
       border: none;
       background-color: #4a90e2;
@@ -67,10 +67,11 @@
       transition: background-color 0.3s ease;
       text-decoration: none;
       width: 100%;
-      max-width: 400px;
+      max-width: 320px;
       text-align: center;
       display: block;
       margin: 0 auto;
+      white-space: nowrap;
     }
 
     .kachel:hover {


### PR DESCRIPTION
## Summary
- Reduce button font size and padding on the start page
- Narrow button width to prevent overly large tiles
- Decrease spacing between welcome header and navigation buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c169ec8a0c8325ba55415b76ba4f8a