### PR TITLE
Prevent caching of second POTD image

### DIFF
--- a/bild-des-tages.html
+++ b/bild-des-tages.html
@@ -84,7 +84,8 @@
       karte.className = "bild-karte";
 
       const bild = document.createElement("img");
-      bild.src = "https://knetenking.kochithelyx.de/potd/potd.jpg";
+      const cacheBuster = Date.now();
+      bild.src = `https://knetenking.kochithelyx.de/potd/potd.jpg?cb=${cacheBuster}`;
       bild.alt = "Bild des Tages von knetenking";
       bild.loading = "lazy";
       karte.appendChild(bild);


### PR DESCRIPTION
## Summary
- add a cache-busting query parameter when loading the external Bild des Tages so the latest photo is always fetched

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d50c8f21c883259a7668188b9b47db